### PR TITLE
Cross platform python

### DIFF
--- a/python/CouchbaseLite/BuildPyCBL.py
+++ b/python/CouchbaseLite/BuildPyCBL.py
@@ -24,6 +24,7 @@
 from cffi import FFI
 import shutil
 import argparse
+import os.path
 
 
 # Mac settings are defaults, but overrideable on command-line
@@ -260,6 +261,9 @@ if __name__ == "__main__":
 
     ffibuilder = FFI()
     extra_link_args = args.link_flags.split()
+    # python 3.5 distutils breaks on Linux with absolute library path,
+    # so make sure it is relative path
+    libdir = os.path.relpath(args.dir)
     ffibuilder.cdef(CDEF)
     ffibuilder.set_source("_PyCBL", r""" // passed to the real C compiler,
         // contains implementation of things declared in cdef()
@@ -267,7 +271,7 @@ if __name__ == "__main__":
     """,
     libraries=[args.name],
     include_dirs=["../../include", "../../vendor/couchbase-lite-core/vendor/fleece/API"],
-    library_dirs=[args.dir],
+    library_dirs=[libdir],
     extra_link_args=extra_link_args)
 
     ffibuilder.compile(verbose=True)


### PR DESCRIPTION
These build-script changes have been tested on cmake, and the generated python bindings pass the tests in test.py on both linux and MacOS. 

The defaults for the build script should make it behave the same as before adding cmake support, to avoid breaking existing workflow for core devs, but this still needs to be tested by someone who actually uses xcode.