### PR TITLE
BasicAuthenticator needs to write the auth type in replication options

### DIFF
--- a/src/CBLReplicatorConfig.hh
+++ b/src/CBLReplicatorConfig.hh
@@ -105,6 +105,7 @@ namespace cbl_internal {
         virtual void writeOptions(Encoder &enc) override {
             enc.writeKey(slice(kC4ReplicatorOptionAuthentication));
             enc.beginDict();
+            enc[slice(kC4ReplicatorAuthType)] = kC4AuthTypeBasic;
             enc[slice(kC4ReplicatorAuthUserName)] = _username;
             enc[slice(kC4ReplicatorAuthPassword)] = _password;
             enc.endDict();


### PR DESCRIPTION
In CivetWebSocket.cc (couchbase-lite-core), the property is used to decide how to do the authentication :

```                
                slice authType = auth[kC4ReplicatorAuthType].asString();
                if (authType == slice(kC4AuthTypeBasic)) {
```

At the moment, any attempt to use basic auth fails with 401 Unsupported auth type.