### PR TITLE
Fix Nim bindings on Linux, and updated README

### DIFF
--- a/bindings/nim/README.md
+++ b/bindings/nim/README.md
@@ -28,8 +28,21 @@ After that, you can use [Nimble][NIMBLE] to build and run:
 
     $ nimble test
 
-(You _should_ be able to run `nimble build`, but that just says "`Error: Nothing to build.`"" I
-don't know why; I'm a newbie at Nim.)
+When compiling on Linux system remember to set `LD_LIBRARY_PATH` to point to the
+directory where `libCouchbaseLiteC.so` exists. If you followed the above steps
+this would look like this:
+
+    $ LD_LIBRARY_PATH=. nimble test
+
+Without the symlink you can also do:
+
+    $ LD_LIBRARY_PATH=../../build_cmake nimble test
+
+The supplied `CouchbaseLite.nimble` file is used to allow Nimble to run the
+tests. If you want to try the bindings out you can create a `<filename>.nim`
+file in this directory and add `bin = @["<filename>"]` to the
+`CouchbaseLite.nimble` file. You can now run `nimble build` or `nimble run` to
+build or build and run your file with the bindings.
 
 ## Learning
 

--- a/bindings/nim/src/CouchbaseLite/private/cbl.nim
+++ b/bindings/nim/src/CouchbaseLite/private/cbl.nim
@@ -10,7 +10,12 @@
 ##         except I've left out the new "_s"-suffixed alternate functions, which Nim doesn't need.
 
 
-{.push dynlib: "libCouchbaseLiteC.dylib".}
+when defined(Linux):
+  {.push dynlib: "libCouchbaseLiteC.so".}
+elif defined(MacOS) or defined(MacOSX):
+  {.push dynlib: "libCouchbaseLiteC.dylib".}
+elif defined(Windows):
+  {.push dynlib: "libCouchbaseLiteC.dll".}
 
 
 ##

--- a/bindings/nim/src/CouchbaseLite/private/fl.nim
+++ b/bindings/nim/src/CouchbaseLite/private/fl.nim
@@ -10,7 +10,12 @@
 ##         Fleece commit 4ca3dbf1, "Mutable.hh: Allow conversion of keyRef and FLSlot to FLSlot".
 
 
-{.push dynlib: "libCouchbaseLiteC.dylib".}
+when defined(Linux):
+  {.push dynlib: "libCouchbaseLiteC.so".}
+elif defined(MacOS) or defined(MacOSX):
+  {.push dynlib: "libCouchbaseLiteC.dylib".}
+elif defined(Windows):
+  {.push dynlib: "libCouchbaseLiteC.dll".}
 
 
 ##   FLSlice.h

--- a/bindings/nim/src/CouchbaseLite/private/fl.nim
+++ b/bindings/nim/src/CouchbaseLite/private/fl.nim
@@ -15,7 +15,7 @@ when defined(Linux):
 elif defined(MacOS) or defined(MacOSX):
   {.push dynlib: "libCouchbaseLiteC.dylib".}
 elif defined(Windows):
-  {.push dynlib: "libCouchbaseLiteC.dll".}
+  {.push dynlib: "CouchbaseLiteC.dll".}
 
 
 ##   FLSlice.h


### PR DESCRIPTION
This adds a conditional to select the correct name for the dynamic library based on platform. It has a switch for Windows as well, but this remains untested. Also updated the README to include how to run on Linux and explain why `nimble build` doesn't do anything (because it's a library package and not a binary package, `nimble install` would put the library in your nimble path so you could import it directly from your projects).