### PR TITLE
bugfix missing python bindings cdeclarations

### DIFF
--- a/bindings/python/BuildPyCBL.py
+++ b/bindings/python/BuildPyCBL.py
@@ -261,8 +261,6 @@ const char* CBLDatabase_Name(const CBLDatabase*);
 const char* CBLDatabase_Path(const CBLDatabase*);
 uint64_t CBLDatabase_Count(const CBLDatabase*);
 CBLDatabaseConfiguration CBLDatabase_Config(const CBLDatabase*);
-CBLTimestamp CBLDatabase_NextDocExpiration(CBLDatabase*);
-int64_t CBLDatabase_PurgeExpiredDocuments(CBLDatabase* db, CBLError* error);
 
 typedef void (*CBLDatabaseChangeListener)(void *context,
                                      const CBLDatabase* db,

--- a/src/CBLLog.cc
+++ b/src/CBLLog.cc
@@ -83,7 +83,7 @@ void CBLLog_SetCallback(CBLLogCallback callback) CBLAPI {
 
     sCallback = callback;
     c4log_writeToCallback(c4log_callbackLevel(),
-                          callback ? c4Callback : nullptr,
+                          callback ? c4Callback : (C4LogCallback) nullptr,
                           true);
 }
 


### PR DESCRIPTION
This PR fixes two items:
* compilation error caused by an uncasted nullptr
* Python binding error caused by Cdeclaration of functions that no longer exist.