### PR TITLE
Fix Linux build error

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,7 @@ set(TEST_SRC
 
 add_executable(CBL_C_Tests ${TEST_SRC} )
 
-target_link_libraries(CBL_C_Tests PRIVATE  CouchbaseLiteC FleeceStatic)
+target_link_libraries(CBL_C_Tests PRIVATE  CouchbaseLiteC LiteCoreStatic FleeceStatic)
 
 if(MSVC)
     target_include_directories(


### PR DESCRIPTION
this completely fixes the following error that comes up when doing a build from Linux (Issue #61):

```
Linking CXX executable CBL_C_Tests
/usr/bin/ld: ../libCouchbaseLiteC.so: undefined reference to `litecore::crypto::TLSLogDomain'
/usr/bin/ld: ../libCouchbaseLiteC.so: undefined reference to `litecore::crypto::Cert::Cert(fleece::slice)'
/usr/bin/ld: ../libCouchbaseLiteC.so: undefined reference to `litecore::crypto::Cert::isSelfSigned()'
```
