### PR TITLE
Put LiteCoreStatic inside whole library flag

### DIFF
--- a/CBL_C.xcodeproj/xcshareddata/xcschemes/CBL_C Framework.xcscheme
+++ b/CBL_C.xcodeproj/xcshareddata/xcschemes/CBL_C Framework.xcscheme
@@ -27,15 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "27984E092249A126000FE777"
-            BuildableName = "CouchbaseLite.framework"
-            BlueprintName = "CBL_C Framework"
-            ReferencedContainer = "container:CBL_C.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <Testables>
       </Testables>
    </TestAction>

--- a/CBL_C.xcodeproj/xcshareddata/xcschemes/CBL_Tests.xcscheme
+++ b/CBL_C.xcodeproj/xcshareddata/xcschemes/CBL_Tests.xcscheme
@@ -27,20 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "27B61DA721D6E49D0027CCDB"
-            BuildableName = "CBL_Tests"
-            BlueprintName = "CBL_Tests"
-            ReferencedContainer = "container:CBL_C.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <TestPlans>
-         <TestPlanReference
-            reference = "container:Xcode/CBL_Tests.xctestplan"
-            default = "YES">
-         </TestPlanReference>
       </TestPlans>
    </TestAction>
    <LaunchAction

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,8 +128,8 @@ install (TARGETS CouchbaseLiteC
 set(CBL_LIBRARIES_PRIVATE  ${WHOLE_LIBRARY_FLAG}
                             CouchbaseLiteCStatic
                             FleeceStatic
-                           ${NO_WHOLE_LIBRARY_FLAG}
                             LiteCoreStatic
+                           ${NO_WHOLE_LIBRARY_FLAG}
                             LiteCoreWebSocket)
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^armv[67]")

--- a/include/cbl/CBL_Compat.h
+++ b/include/cbl/CBL_Compat.h
@@ -36,7 +36,7 @@
     #define _cbl_nonnull            _In_
     #define _cbl_returns_nonnull    _Ret_notnull_
     #define _cbl_warn_unused        _Check_return_
-    #define _cbl_deprecated(MSG,REPLACEMENT)
+    #define _cbl_deprecated
 #else
     #define CBLINLINE            inline
     #define _cbl_returns_nonnull __attribute__((returns_nonnull))

--- a/jenkins/jenkins_unix.sh
+++ b/jenkins/jenkins_unix.sh
@@ -4,8 +4,7 @@ set -e
 shopt -s extglob dotglob
 
 function build_xcode {
-    xcodebuild -project CBL_C.xcodeproj -configuration Debug-EE -derivedDataPath ios -scheme "CBL_C framework" -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO
-    popd
+    xcodebuild -project CBL_C.xcodeproj -configuration Debug-EE -derivedDataPath ios -scheme "CBL_C Framework" -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO
 }
 
 

--- a/src/CBLReplicatorConfig.hh
+++ b/src/CBLReplicatorConfig.hh
@@ -76,7 +76,7 @@ namespace cbl_internal {
         virtual C4Database* otherLocalDB() const override       {return _db->_getC4Database();}
 
     private:
-        Retained<CBLDatabase> _db;
+        fleece::Retained<CBLDatabase> _db;
     };
 #endif
 }


### PR DESCRIPTION
Linking on Linux makes no sense to me, but apparently unless I instruct it to bring in the whole static library it will ignore important bits when linking a dynamic library and cause undefined references later.

Fixes #61 