### PR TITLE
Expose the Blob GetFilePath

### DIFF
--- a/include/cbl/CBLBlob.h
+++ b/include/cbl/CBLBlob.h
@@ -100,6 +100,16 @@ extern "C" {
         @warning  This can potentially allocate a very large heap block! */
     FLSliceResult CBLBlob_LoadContent(const CBLBlob* _cbl_nonnull, CBLError *outError) CBLAPI;
 
+
+    /** Returns the path of the file that stores the blob, if possible. This call may fail with
+        error kC4ErrorWrongFormat if the blob is encrypted (in which case the file would be
+        unreadable by the caller) or with kC4ErrorUnsupported if for some implementation reason
+        the blob isn't stored as a standalone file.
+        Thus, the caller MUST use this function only as an optimization, and fall back to reading
+        the contents via the API if it fails.
+        Also, it goes without saying that the caller MUST not modify the file! */
+    FLStringResult CBLBlob_GetFilePath(const CBLBlob* blob, CBLError *outError) CBLAPI;
+
     /** A stream for reading a blob's content. */
     typedef struct CBLBlobReadStream CBLBlobReadStream;
 

--- a/src/CBLBlob.cc
+++ b/src/CBLBlob.cc
@@ -61,6 +61,10 @@ FLSliceResult CBLBlob_LoadContent(const CBLBlob* blob, CBLError *outError) CBLAP
     return blob->getContents(internal(outError));
 }
 
+FLStringResult CBLBlob_GetFilePath(const CBLBlob* blob, CBLError *outError) CBLAPI {
+    return blob->getFilePath(internal(outError));
+}
+
 CBLBlobReadStream* CBLBlob_OpenContentStream(const CBLBlob* blob, CBLError *outError) CBLAPI {
     return (CBLBlobReadStream*)blob->openStream(internal(outError));
 }
@@ -157,4 +161,3 @@ void FLMutableDict_SetBlob(FLMutableDict dict _cbl_nonnull,
 {
     FLSlot_SetBlob(FLMutableDict_Set(dict, key), blob);
 }
-

--- a/src/CBLBlob_Internal.hh
+++ b/src/CBLBlob_Internal.hh
@@ -75,6 +75,10 @@ public:
         return c4blob_getContents(store(), _key, outError);
     }
 
+    virtual FLStringResult getFilePath(C4Error *outError) const {
+        return c4blob_getFilePath(store(), _key, outError);
+    }
+
     virtual C4ReadStream* openStream(C4Error *outError) const {
         return c4blob_openReadStream(store(), _key, outError);
     }
@@ -165,6 +169,11 @@ public:
                      slice("Can't get streamed blob contents until doc is saved"));
             return FLSliceResult{};
         }
+    }
+
+    virtual FLStringResult getFilePath(C4Error *outError) const override {
+        setError(outError, LiteCoreDomain, kC4ErrorNotFound, slice("Can't get blob path until doc is saved"));
+        return FLStringResult{};
     }
 
     virtual c4ReadStream* openStream(C4Error *outError) const override {

--- a/src/exports/CBL.def
+++ b/src/exports/CBL.def
@@ -74,6 +74,7 @@ CBLBlob_Length
 CBLBlob_Digest
 CBLBlob_Properties
 CBLBlob_LoadContent
+CBLBlob_GetFilePath
 CBLBlob_OpenContentStream
 CBLBlob_CreateWithData
 CBLBlob_CreateWithStream


### PR DESCRIPTION
In my Dart wrapper it is probably more efficient and a lot easier for me to read the content of the blob file using Dart's file api, instead of calling into C and having to allocate and manage memory on the C side. In particular because I have compatibility issues between FLSlice, FLSliceResults and FLStringResults with Dart - whenever I use them either as function parameter or return value, the program crashes. 


I have this code that exposes getfilepath method that I can then use to retrieve the data.
Of course it is an optimization and I do revert using the GetContent if the path call fails.