### PR TITLE
Copy CBL.def to src, remove undefined CBL_SetLogLevel

### DIFF
--- a/cmake/platform_win.cmake
+++ b/cmake/platform_win.cmake
@@ -50,7 +50,7 @@ function(set_dylib_properties)
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /nodefaultlib:kernel32.lib /nodefaultlib:ole32.lib")
     endif()
     set_target_properties(CouchbaseLiteC PROPERTIES LINK_FLAGS
-        "/def:${PROJECT_SOURCE_DIR}/src/CBL.def")
+        "/def:${PROJECT_SOURCE_DIR}/src/exports/CBL.def")
     target_link_libraries(CouchbaseLiteC PRIVATE zlibstatic Ws2_32)
     target_compile_definitions(CouchbaseLiteCStatic PRIVATE LITECORE_EXPORTS)
 endfunction()

--- a/include/cbl++/Database.hh
+++ b/include/cbl++/Database.hh
@@ -20,6 +20,7 @@
 #include "Base.hh"
 #include "CBLDatabase.h"
 #include "CBLDocument.h"
+#include "CBLLog.h"
 #include "CBLQuery.h"
 #include "fleece/Mutable.hh"
 #include <functional>

--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -17,7 +17,11 @@
 //
 
 #pragma once
+
 #include "CBLReplicator.h"
+
+#include "Document.hh"
+
 #include <functional>
 
 // PLEASE NOTE: This C++ wrapper API is provided as a convenience only.

--- a/src/exports/CBL.def
+++ b/src/exports/CBL.def
@@ -8,6 +8,16 @@ CBL_DumpInstances
 CBL_Log
 CBL_Log_s
 
+CBLLog_Callback
+CBLLog_SetCallback
+CBLLog_ConsoleLevel
+CBLLog_ConsoleLevelOfDomain
+CBLLog_SetConsoleLevel
+CBLLog_SetConsoleLevelOfDomain
+CBLLog_WillLogToConsole
+CBLLog_FileConfig
+CBLLog_SetFileConfig
+
 CBL_Now
 
 CBLError_Message

--- a/src/exports/CBL.def
+++ b/src/exports/CBL.def
@@ -7,7 +7,6 @@ CBL_DumpInstances
 
 CBL_Log
 CBL_Log_s
-CBL_SetLogLevel
 
 CBL_Now
 


### PR DESCRIPTION
This commit solves the 
`LNK1104	cannot open file '${CB_PATH}/couchbase-forked/couchbase-lite-C/src/CBL.def'`
and the 
`LNK2001	unresolved external symbol CBL_SetLogLevel	CouchbaseLiteC	${CB_PATH}\couchbase-lite-C\build_cmake\CBL.def`
errors when building in VIsual Studio.

It adds CBLLog_SetConsoleLevel to the public interface and adds the required includes in the Replicator.hh and Database.hh files.