### PR TITLE
Apply API changes and fix test fails

### DIFF
--- a/include/cbl/CBLDatabase.h
+++ b/include/cbl/CBLDatabase.h
@@ -33,15 +33,6 @@ extern "C" {
 /** \name  Database configuration
     @{ */
 
-/** Flags for how to open a database. */
-typedef CBL_OPTIONS(uint32_t, CBLDatabaseFlags) {
-    kCBLDatabase_Create        = 1,  ///< Create the file if it doesn't exist
-    kCBLDatabase_ReadOnly      = 2,  ///< Open file read-only
-    kCBLDatabase_NoUpgrade     = 4,  ///< Disable upgrading an older-version database
-
-    kCBLDatabase_VersionVectors = 0x8000, ///< EXPERIMENTAL: Upgrade DB to use version vectors
-};
-
 /** Database encryption algorithms (available only in the Enterprise Edition). */
 typedef CBL_ENUM(uint32_t, CBLEncryptionAlgorithm) {
     kCBLEncryptionNone = 0,      ///< No encryption (default)
@@ -64,7 +55,6 @@ typedef struct CBLEncryptionKey {
 /** Database configuration options. */
 typedef struct {
     FLString directory;                     ///< The parent directory of the database
-    CBLDatabaseFlags flags;                 ///< Options for opening the database
     CBLEncryptionKey* encryptionKey;        ///< The database's encryption key (if any)
 } CBLDatabaseConfiguration;
 

--- a/include/cbl/CBLDocument.h
+++ b/include/cbl/CBLDocument.h
@@ -191,7 +191,7 @@ CBLDocument* CBLDatabase_GetMutableDocument(CBLDatabase* database,
     It will not be added to a database until saved.
     @return  The new mutable document instance. */
 _cbl_warn_unused
-CBLDocument* CBLDocument_New(void) CBLAPI _cbl_returns_nonnull;
+CBLDocument* CBLDocument_Create(void) CBLAPI _cbl_returns_nonnull;
 
 /** Creates a new, empty document in memory, with the given ID.
     It will not be added to a database until saved.
@@ -201,7 +201,7 @@ CBLDocument* CBLDocument_New(void) CBLAPI _cbl_returns_nonnull;
     @param docID  The ID of the new document, or NULL to assign a new unique ID.
     @return  The new mutable document instance. */
 _cbl_warn_unused
-CBLDocument* CBLDocument_NewWithID(FLString docID) CBLAPI _cbl_returns_nonnull;
+CBLDocument* CBLDocument_CreateWithID(FLString docID) CBLAPI _cbl_returns_nonnull;
 
 /** Creates a new mutable CBLDocument instance that refers to the same document as the original.
     If the original document has unsaved changes, the new one will also start out with the same
@@ -209,7 +209,7 @@ CBLDocument* CBLDocument_NewWithID(FLString docID) CBLAPI _cbl_returns_nonnull;
     @note  You must release the new reference when you're done with it. Similarly, the original
            document still exists and must also be released when you're done with it.*/
 _cbl_warn_unused
-CBLDocument* CBLDocument_ToMutable(const CBLDocument* original _cbl_nonnull) CBLAPI
+CBLDocument* CBLDocument_MutableCopy(const CBLDocument* original _cbl_nonnull) CBLAPI
     _cbl_returns_nonnull;
 
 /** @} */
@@ -267,7 +267,7 @@ void CBLDocument_SetProperties(CBLDocument* _cbl_nonnull,
 /** Returns a document's properties as JSON.
     @note  You are responsible for releasing the result by calling \ref FLSliceResult_Release. */
 _cbl_warn_unused
-FLSliceResult CBLDocument_ToJSON(const CBLDocument* _cbl_nonnull) CBLAPI;
+FLSliceResult CBLDocument_CreateJSON(const CBLDocument* _cbl_nonnull) CBLAPI;
 
 /** Sets a mutable document's properties from a JSON string. */
 bool CBLDocument_SetJSON(CBLDocument* _cbl_nonnull,

--- a/src/CBLDatabase_Internal.hh
+++ b/src/CBLDatabase_Internal.hh
@@ -35,11 +35,9 @@ class CBLDatabase final : public CBLRefCounted, public litecore::access_lock<C4D
 public:
     CBLDatabase(C4Database* _cbl_nonnull db,
                 slice name_,
-                slice dir_,
-                CBLDatabaseFlags flags_)
+                slice dir_)
     :access_lock(std::move(db))
     ,dir(dir_)
-    ,flags(flags_)
     ,_blobStore(c4db_getBlobStore(db, nullptr))
     ,_notificationQueue(this)
     { }
@@ -56,7 +54,6 @@ public:
     static std::string defaultDirectory();
 
     alloc_slice const dir;
-    CBLDatabaseFlags const flags;
 
     RetainedConst<CBLDocument> getDocument(slice docID, bool allRevisions, CBLError*) const;
 

--- a/src/CBLDocument.cc
+++ b/src/CBLDocument.cc
@@ -499,15 +499,15 @@ bool CBLDocument::saveBlobs(CBLDatabase *db, bool &outHasBlobs, C4Error *outErro
 #pragma mark - PUBLIC API:
 
 
-CBLDocument* CBLDocument_New() CBLAPI {
-    return CBLDocument_NewWithID(nullslice);
+CBLDocument* CBLDocument_Create() CBLAPI {
+    return CBLDocument_CreateWithID(nullslice);
 }
 
-CBLDocument* CBLDocument_NewWithID(FLString docID) CBLAPI {
+CBLDocument* CBLDocument_CreateWithID(FLString docID) CBLAPI {
     return make_nothrow<CBLDocument>(nullptr, docID, true).detach();
 }
 
-CBLDocument* CBLDocument_ToMutable(const CBLDocument* doc) CBLAPI {
+CBLDocument* CBLDocument_MutableCopy(const CBLDocument* doc) CBLAPI {
     return make_nothrow<CBLDocument>(nullptr, doc).detach();
 }
 
@@ -517,7 +517,7 @@ uint64_t CBLDocument_Sequence(const CBLDocument* doc) CBLAPI           {return d
 FLDict CBLDocument_Properties(const CBLDocument* doc) CBLAPI           {return doc->properties();}
 FLMutableDict CBLDocument_MutableProperties(CBLDocument* doc) CBLAPI   {return doc->mutableProperties();}
 
-FLSliceResult CBLDocument_ToJSON(const CBLDocument* doc) CBLAPI {return FLSliceResult(doc->propertiesAsJSON());}
+FLSliceResult CBLDocument_CreateJSON(const CBLDocument* doc) CBLAPI {return FLSliceResult(doc->propertiesAsJSON());}
 
 void CBLDocument_SetProperties(CBLDocument* doc, FLMutableDict properties _cbl_nonnull) CBLAPI {
     doc->setProperties(properties);

--- a/src/exports/CBL_Exports.txt
+++ b/src/exports/CBL_Exports.txt
@@ -81,13 +81,13 @@ CBLDatabase_IndexNames
 CBLDocument_ID
 CBLDocument_RevisionID
 CBLDocument_Sequence
-CBLDocument_New
-CBLDocument_NewWithID
-CBLDocument_ToMutable
+CBLDocument_Create
+CBLDocument_CreateWithID
+CBLDocument_MutableCopy
 CBLDocument_Properties
 CBLDocument_MutableProperties
 CBLDocument_SetProperties
-CBLDocument_ToJSON
+CBLDocument_CreateJSON
 CBLDocument_SetJSON
 
 CBLDatabase_GetDocument

--- a/src/exports/generated/CBL.def
+++ b/src/exports/generated/CBL.def
@@ -57,13 +57,13 @@ CBLDatabase_IndexNames
 CBLDocument_ID
 CBLDocument_RevisionID
 CBLDocument_Sequence
-CBLDocument_New
-CBLDocument_NewWithID
-CBLDocument_ToMutable
+CBLDocument_Create
+CBLDocument_CreateWithID
+CBLDocument_MutableCopy
 CBLDocument_Properties
 CBLDocument_MutableProperties
 CBLDocument_SetProperties
-CBLDocument_ToJSON
+CBLDocument_CreateJSON
 CBLDocument_SetJSON
 CBLDatabase_GetDocument
 CBLDatabase_GetMutableDocument

--- a/src/exports/generated/CBL.exp
+++ b/src/exports/generated/CBL.exp
@@ -55,13 +55,13 @@ _CBLDatabase_IndexNames
 _CBLDocument_ID
 _CBLDocument_RevisionID
 _CBLDocument_Sequence
-_CBLDocument_New
-_CBLDocument_NewWithID
-_CBLDocument_ToMutable
+_CBLDocument_Create
+_CBLDocument_CreateWithID
+_CBLDocument_MutableCopy
 _CBLDocument_Properties
 _CBLDocument_MutableProperties
 _CBLDocument_SetProperties
-_CBLDocument_ToJSON
+_CBLDocument_CreateJSON
 _CBLDocument_SetJSON
 _CBLDatabase_GetDocument
 _CBLDatabase_GetMutableDocument

--- a/src/exports/generated/CBL.gnu
+++ b/src/exports/generated/CBL.gnu
@@ -55,14 +55,13 @@ CBL_C {
 		CBLDocument_ID;
 		CBLDocument_RevisionID;
 		CBLDocument_Sequence;
-		CBLDocument_New;
-		CBLDocument_NewWithID;
-		CBLDocument_ToMutable;
+		CBLDocument_Create;
+		CBLDocument_CreateWithID;
+		CBLDocument_MutableCopy;
 		CBLDocument_Properties;
 		CBLDocument_MutableProperties;
 		CBLDocument_SetProperties;
-		CBLDocument_ToFleeceDoc;
-		CBLDocument_ToJSON;
+		CBLDocument_CreateJSON;
 		CBLDocument_SetJSON;
 		CBLDatabase_GetDocument;
 		CBLDatabase_GetMutableDocument;

--- a/src/exports/generated/CBL_EE.def
+++ b/src/exports/generated/CBL_EE.def
@@ -66,13 +66,13 @@ CBLDatabase_IndexNames
 CBLDocument_ID
 CBLDocument_RevisionID
 CBLDocument_Sequence
-CBLDocument_New
-CBLDocument_NewWithID
-CBLDocument_ToMutable
+CBLDocument_Create
+CBLDocument_CreateWithID
+CBLDocument_MutableCopy
 CBLDocument_Properties
 CBLDocument_MutableProperties
 CBLDocument_SetProperties
-CBLDocument_ToJSON
+CBLDocument_CreateJSON
 CBLDocument_SetJSON
 CBLDatabase_GetDocument
 CBLDatabase_GetMutableDocument

--- a/src/exports/generated/CBL_EE.exp
+++ b/src/exports/generated/CBL_EE.exp
@@ -64,13 +64,13 @@ _CBLDatabase_IndexNames
 _CBLDocument_ID
 _CBLDocument_RevisionID
 _CBLDocument_Sequence
-_CBLDocument_New
-_CBLDocument_NewWithID
-_CBLDocument_ToMutable
+_CBLDocument_Create
+_CBLDocument_CreateWithID
+_CBLDocument_MutableCopy
 _CBLDocument_Properties
 _CBLDocument_MutableProperties
 _CBLDocument_SetProperties
-_CBLDocument_ToJSON
+_CBLDocument_CreateJSON
 _CBLDocument_SetJSON
 _CBLDatabase_GetDocument
 _CBLDatabase_GetMutableDocument

--- a/src/exports/generated/CBL_EE.gnu
+++ b/src/exports/generated/CBL_EE.gnu
@@ -64,13 +64,13 @@ CBL_C {
 		CBLDocument_ID;
 		CBLDocument_RevisionID;
 		CBLDocument_Sequence;
-		CBLDocument_New;
-		CBLDocument_NewWithID;
-		CBLDocument_ToMutable;
+		CBLDocument_Create;
+		CBLDocument_CreateWithID;
+		CBLDocument_MutableCopy;
 		CBLDocument_Properties;
 		CBLDocument_MutableProperties;
 		CBLDocument_SetProperties;
-		CBLDocument_ToJSON;
+		CBLDocument_CreateJSON;
 		CBLDocument_SetJSON;
 		CBLDatabase_GetDocument;
 		CBLDatabase_GetMutableDocument;

--- a/test/CBLTest.cc
+++ b/test/CBLTest.cc
@@ -53,7 +53,6 @@ slice       const CBLTest::kDatabaseName = "CBLtest";
 
 const CBLDatabaseConfiguration CBLTest::kDatabaseConfiguration = []{
     CBLDatabaseConfiguration config = {kDatabaseDir};
-    config.flags = kCBLDatabase_Create;
     return config;
 }();
 
@@ -173,7 +172,7 @@ unsigned ImportJSONLines(string&& path, CBLDatabase* database) {
     ReadFileByLines(path, [&](FLSlice line) {
         char docID[20];
         sprintf(docID, "%07u", numDocs+1);
-        auto doc = CBLDocument_NewWithID(slice(docID));
+        auto doc = CBLDocument_CreateWithID(slice(docID));
         REQUIRE(CBLDocument_SetJSON(doc, line, &error));
         CHECK(CBLDatabase_SaveDocumentWithConcurrencyControl(database, doc, kCBLConcurrencyControlFailOnConflict, &error));
         CBLDocument_Release(doc);

--- a/test/DatabaseTest_Cpp.cc
+++ b/test/DatabaseTest_Cpp.cc
@@ -132,7 +132,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Transaction, Aborted") {
 }
 
 
-TEST_CASE_METHOD(CBLTest_Cpp, "C++ Batch With Exception", "[!throws]") {
+TEST_CASE_METHOD(CBLTest_Cpp, "C++ Transaction With Exception", "[!throws]") {
     bool threw = false;
     try {
         Transaction t(db);
@@ -156,8 +156,7 @@ TEST_CASE_METHOD(CBLTest_Cpp, "C++ Batch With Exception", "[!throws]") {
     CHECK(threw);
 
     Document doc = db.getDocument("foo");
-    CHECK(doc["greeting"].asString() == "Howdy!");
-    CHECK(doc["meeting"] == nullptr);
+    REQUIRE(!doc);
 }
 
 


### PR DESCRIPTION
- Removed CBLDatabaseConfiguration.flags and used kC4DB_Create | kC4DB_VersionVectors by default.
- Renamed create object functions that use *New* to *Create*.
- Renamed CBLDocument_ToMutable to CBLDocument_MutableCopy.
- Renamed CBLDocument_ToJSON to CBLDocument_CreateJSON.
- Fixed cbl++/Document’s adopt() to return null when document is not found instead of throwing an exception.
- Fixed Save Empty Document to check RevID in non-version-vector format.
- Fixed C++ Batch With Exception Test.
- NOTE: This PR will be merged to dev branch.