### PR TITLE
Fix missing link with LiteCoreREST_Static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ install (TARGETS CouchbaseLiteC
 set(CBL_LIBRARIES_PRIVATE  ${WHOLE_LIBRARY_FLAG}
                             CouchbaseLiteCStatic
                             LiteCoreStatic
+                            LiteCoreREST_Static
                            ${NO_WHOLE_LIBRARY_FLAG}
                             LiteCoreWebSocket)
 


### PR DESCRIPTION
Added link with LiteCoreREST_Static for any calls to c4listener.