### PR TITLE
Fix GH Action Test Path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,11 +70,18 @@ jobs:
       if: runner.os != 'Windows'
       working-directory: ${{github.workspace}}
       shell: bash
-      run: build/test/CBL_C_Tests -r list
+      run: |
+        pushd build/test
+        ./CBL_C_Tests -r list
+        popd
 
     - name: Test On Windows
       if: runner.os == 'Windows'
       working-directory: ${{github.workspace}}
       shell: bash
       # Windows CMake puts the binary in a subdirectory named after the build type...
-      run: build/test/$BUILD_TYPE/CBL_C_Tests -r list
+      run: |
+        mkdir -p /c/tmp
+        pushd build/test/$BUILD_TYPE
+        ./CBL_C_Tests.exe -r list
+        popd


### PR DESCRIPTION
* Problem : (1) running tests on Windows was hang as the tmp needs to be created before running the test (2) the path to `names_100.json` used in the test is not correct on Windows due to the path used to run the test.
* Fixed the running test path so that `names_100.json` can be accessed correctly on both Windows and others.
* Create tmp folder before running the test on Windows, otherwise the tests will be just hang.