### PR TITLE
Generate CBL_Edition.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bin
 *.dylib
 empty.cpp
 vendor/couchbase-lite-core-EE
+Xcode/generated_headers
 
 # Editors
 .vscode
@@ -13,7 +14,6 @@ vendor/couchbase-lite-core-EE
 
 # Xcode
 xcuserdata
-
 
 # Python
 python/CouchbaseLite/*.c

--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -385,6 +385,7 @@
 		27DBCF41246B81EE002FD7A7 /* LibC++Debug.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "LibC++Debug.cc"; sourceTree = "<group>"; };
 		27DBD096246C99AF002FD7A7 /* mergeIntoStaticLib.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = mergeIntoStaticLib.sh; sourceTree = "<group>"; };
 		27DBD097246C9DE7002FD7A7 /* CBLDatabase+Apple.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "CBLDatabase+Apple.mm"; sourceTree = "<group>"; };
+		93D0AFF1262619B800777AFC /* generate_edition_header.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = generate_edition_header.sh; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -614,6 +615,7 @@
 				27B61D8421D6BA060027CCDB /* xcconfigs */,
 				27DBD096246C99AF002FD7A7 /* mergeIntoStaticLib.sh */,
 				274BAB9D24DA2DB900F4F810 /* generate_exports.sh */,
+				93D0AFF1262619B800777AFC /* generate_edition_header.sh */,
 			);
 			path = Xcode;
 			sourceTree = "<group>";
@@ -755,6 +757,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 271C2A2721CAC8920045856E /* Build configuration list for PBXNativeTarget "CBL_C" */;
 			buildPhases = (
+				93D0AF98262559ED00777AFC /* Generate CBL_Edition.h */,
 				271C2A1F21CAC8920045856E /* Headers */,
 				271C2A2021CAC8920045856E /* Sources */,
 				27DBD088246C94B2002FD7A7 /* Merge static libs */,
@@ -793,11 +796,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 27984E1B2249A127000FE777 /* Build configuration list for PBXNativeTarget "CBL_C Framework" */;
 			buildPhases = (
+				93D0AF88262557D200777AFC /* Generate CBL_Edition.h */,
 				279157C824E1CAF2008B56FE /* Generate Export List */,
 				27984E052249A126000FE777 /* Headers */,
 				27984E062249A126000FE777 /* Sources */,
 				27984E072249A126000FE777 /* Frameworks */,
 				27984E382249A36A000FE777 /* Copy Fleece Headers */,
+				93D0AFB626255E7300777AFC /* Copy CBL_Editionh */,
 			);
 			buildRules = (
 			);
@@ -1107,6 +1112,64 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = "/bin/bash -e";
 			shellScript = "# This script merges the input files into the static lib built by this target.\nsource $SRCROOT/Xcode/mergeIntoStaticLib.sh\n";
+		};
+		93D0AF88262557D200777AFC /* Generate CBL_Edition.h */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Xcode/generate_edition_header.sh",
+			);
+			name = "Generate CBL_Edition.h";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$SCRIPT_INPUT_FILE_0\"\n";
+		};
+		93D0AF98262559ED00777AFC /* Generate CBL_Edition.h */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Xcode/generate_edition_header.sh",
+			);
+			name = "Generate CBL_Edition.h";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$SCRIPT_INPUT_FILE_0\"\n";
+		};
+		93D0AFB626255E7300777AFC /* Copy CBL_Editionh */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(DERIVED_FILE_DIR)/CBL_Edition.h",
+			);
+			name = "Copy CBL_Editionh";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(PUBLIC_HEADERS_FOLDER_PATH)",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\ncp \"$SCRIPT_INPUT_FILE_0\" \"$SCRIPT_OUTPUT_FILE_0\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,13 @@ endif()
 
 if(BUILD_ENTERPRISE)
     add_definitions(-DCOUCHBASE_ENTERPRISE)         # Tells CBL it's an EE build
+    set(COUCHBASE_ENTERPRISE 1)                     # For generating CBL_Edition.h
 endif()
+
+configure_file(
+    "${PROJECT_SOURCE_DIR}/include/cbl/CBL_Edition.h.in"
+    "${PROJECT_BINARY_DIR}/generated_headers/public/cbl/CBL_Edition.h"
+)
 
 add_definitions("-DCMAKE")
 include(CheckIncludeFile)
@@ -36,7 +42,7 @@ check_function_exists(vasprintf CBL_HAVE_VASPRINTF)
 
 configure_file(
     "${PROJECT_SOURCE_DIR}/include/cbl/cbl_config.h.in"
-    "${PROJECT_BINARY_DIR}/include/cbl/cbl_config.h"
+    "${PROJECT_BINARY_DIR}/generated_headers/private/cbl/cbl_config.h"
 )
 if(MSVC)
     include("cmake/platform_win.cmake")
@@ -94,14 +100,19 @@ set(
 )
 
 add_library(CouchbaseLiteCStatic STATIC ${ALL_SRC_FILES})
-target_include_directories(CouchbaseLiteCStatic PUBLIC include/cbl)
+target_include_directories(
+    CouchbaseLiteCStatic
+    PUBLIC
+    include/cbl
+    ${PROJECT_BINARY_DIR}/generated_headers/public/cbl
+)
 set_platform_include_directories(RESULT PLATFORM_INCLUDE)
 target_include_directories(
     CouchbaseLiteCStatic 
     PRIVATE
     src
     vendor/couchbase-lite-core/C
-    ${PROJECT_BINARY_DIR}/include/cbl/
+    ${PROJECT_BINARY_DIR}/generated_headers/private/cbl
     ${PLATFORM_INCLUDE}
 )
 
@@ -112,13 +123,18 @@ target_link_libraries(
 
 file(WRITE empty.cpp)
 add_library(CouchbaseLiteC SHARED empty.cpp)
-target_include_directories(CouchbaseLiteC PUBLIC include/cbl)
+target_include_directories(
+    CouchbaseLiteC
+    PUBLIC
+    include/cbl
+    ${PROJECT_BINARY_DIR}/generated_headers/public/cbl
+)
 target_include_directories(
     CouchbaseLiteC
     PRIVATE
     src
     vendor/couchbase-lite-core/C
-    ${PROJECT_BINARY_DIR}/include/cbl/
+    ${PROJECT_BINARY_DIR}/generated_headers/private/cbl
     ${PLATFORM_INCLUDE}
 )
 

--- a/Xcode/generate_edition_header.sh
+++ b/Xcode/generate_edition_header.sh
@@ -1,0 +1,21 @@
+#! /bin/bash -e
+#
+# Xcode build script to generate the CBL-C CBL_Edition.h
+
+# Input file:
+INPUT_FILE="$SRCROOT/include/cbl/CBL_Edition.h.in"
+
+# Output directory:
+OUTPUT_DIR="$SRCROOT/Xcode/generated_headers"
+OUTPUT_FILE="$OUTPUT_DIR/CBL_Edition.h"
+
+mkdir -p "$OUTPUT_DIR"
+
+if [ "$CONFIGURATION" == "Debug_EE" ] || [ "$CONFIGURATION" == "Release_EE" ]; then
+  cat "$INPUT_FILE" | sed 's/#cmakedefine/#define/g' > "$OUTPUT_DIR/CBL_Edition.h"
+else
+  cat "$INPUT_FILE" | sed 's/#cmakedefine\(.*\)/\/\* #undef\1 \*\//g' > "$OUTPUT_FILE"
+fi
+
+# Copy to the derived file directory for building and installing:
+cp "$OUTPUT_FILE" "$DERIVED_FILE_DIR/CBL_Edition.h"

--- a/Xcode/xcconfigs/Tests.xcconfig
+++ b/Xcode/xcconfigs/Tests.xcconfig
@@ -6,5 +6,5 @@
 //  Copyright © 2018 Couchbase. All rights reserved.
 //
 
-HEADER_SEARCH_PATHS     = include  $(FLEECE)/API  $(FLEECE)/Fleece/Support  $(FLEECE)/vendor/catch
+HEADER_SEARCH_PATHS     = include Xcode/generated_headers $(FLEECE)/API  $(FLEECE)/Fleece/Support  $(FLEECE)/vendor/catch
 PRODUCT_NAME            = cbl_tests

--- a/Xcode/xcconfigs/XCTests.xcconfig
+++ b/Xcode/xcconfigs/XCTests.xcconfig
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Couchbase. All rights reserved.
 //
 
-HEADER_SEARCH_PATHS     = include  $(FLEECE)/API  $(FLEECE)/Fleece/Support  $(FLEECE)/vendor/catch
+HEADER_SEARCH_PATHS     = include  Xcode/generated_headers  $(FLEECE)/API  $(FLEECE)/Fleece/Support  $(FLEECE)/vendor/catch
 
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/.. @loader_path/..
 

--- a/include/cbl/CBLBase.h
+++ b/include/cbl/CBLBase.h
@@ -21,6 +21,7 @@
 #include "cbl_config.h"
 #endif
 
+#include "CBL_Edition.h"
 #include "CBL_Compat.h"
 #include "fleece/FLSlice.h"
 #include <stdbool.h>

--- a/include/cbl/CBL_Edition.h.in
+++ b/include/cbl/CBL_Edition.h.in
@@ -1,0 +1,21 @@
+//
+// CBL_Edition.h
+//
+// Copyright (c) 2018 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef COUCHBASE_ENTERPRISE
+#cmakedefine COUCHBASE_ENTERPRISE
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,7 @@ include_directories(
     ${TOP}vendor/couchbase-lite-core/vendor/fleece/API/
     ${TOP}vendor/couchbase-lite-core/vendor/fleece/vendor/catch/
     ${TOP}vendor/couchbase-lite-core/vendor/fleece/vendor/libb64/
-    ${PROJECT_BINARY_DIR}/../include/cbl/
+    ${PROJECT_BINARY_DIR}/../generated_headers/private/cbl/ # Real independent projects won't need this
 )
 
 set(TEST_SRC


### PR DESCRIPTION
* Generated CBL_Edition.h which defines COUCHBASE_ENTERPRISE when building EE edition. The CBL_Edition.h file is generated from CBL_Edition.h.in.
* Added generate_edition_header.sh script for generating CBL_Edition.h from XCode.
* In XCode project, added build phase for CBL_C and CBL_C Framework target to generate and copy CBL_Edition.h.
* In XCode project, added Xcode/generate_headers to the header search path of the test targets.