### PR TITLE
Fixed build failure as kCBLLogDomainDatabase is undeclared

### DIFF
--- a/include/cbl++/Database.hh
+++ b/include/cbl++/Database.hh
@@ -21,6 +21,7 @@
 #include "cbl/CBLDatabase.h"
 #include "cbl/CBLDocument.h"
 #include "cbl/CBLQuery.h"
+#include "cbl/CBLLog.h"
 #include "fleece/Mutable.hh"
 #include <functional>
 #include <string>


### PR DESCRIPTION
Fixed build error as "Database.hh:273:33: error: use of undeclared identifier kCBLLogDomainDatabase" by including CBLLog.h in Database.hh