### PR TITLE
Add a script for building xcframework

### DIFF
--- a/.github/workflows/applebuild.yml
+++ b/.github/workflows/applebuild.yml
@@ -1,0 +1,23 @@
+name: Build Apple
+
+on:
+  push:
+    branches:
+      - master
+      - dev
+      - "release/*"
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  build:
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: "Build"
+        working-directory: ${{github.workspace}}
+        run: scripts/build_apple.sh

--- a/CBL_C.xcodeproj/project.pbxproj
+++ b/CBL_C.xcodeproj/project.pbxproj
@@ -58,13 +58,13 @@
 		27984E2E2249A240000FE777 /* CBLQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 271C2A3021CAC98F0045856E /* CBLQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		27984E2F2249A240000FE777 /* CBLReplicator.h in Headers */ = {isa = PBXBuildFile; fileRef = 271C2A2C21CAC98F0045856E /* CBLReplicator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		27984E302249A240000FE777 /* CBL_Compat.h in Headers */ = {isa = PBXBuildFile; fileRef = 271C2A7021CAD6440045856E /* CBL_Compat.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		27984E312249A247000FE777 /* CouchbaseLite.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE5021E6BC2100B60E3C /* CouchbaseLite.hh */; settings = {ATTRIBUTES = (Public, ); }; };
-		27984E322249A247000FE777 /* Base.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE3D21DEF0C700B60E3C /* Base.hh */; settings = {ATTRIBUTES = (Public, ); }; };
-		27984E332249A247000FE777 /* Blob.hh in Headers */ = {isa = PBXBuildFile; fileRef = 275BC4E22204E6A800DBE7D2 /* Blob.hh */; settings = {ATTRIBUTES = (Public, ); }; };
-		27984E342249A247000FE777 /* Database.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27B61DD821DEEC540027CCDB /* Database.hh */; settings = {ATTRIBUTES = (Public, ); }; };
-		27984E352249A247000FE777 /* Document.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE4E21DEF54D00B60E3C /* Document.hh */; settings = {ATTRIBUTES = (Public, ); }; };
-		27984E362249A247000FE777 /* Query.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE4F21E6AB1100B60E3C /* Query.hh */; settings = {ATTRIBUTES = (Public, ); }; };
-		27984E372249A247000FE777 /* Replicator.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27C9B5F121F7D74A0040BC45 /* Replicator.hh */; settings = {ATTRIBUTES = (Public, ); }; };
+		27984E312249A247000FE777 /* CouchbaseLite.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE5021E6BC2100B60E3C /* CouchbaseLite.hh */; };
+		27984E322249A247000FE777 /* Base.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE3D21DEF0C700B60E3C /* Base.hh */; };
+		27984E332249A247000FE777 /* Blob.hh in Headers */ = {isa = PBXBuildFile; fileRef = 275BC4E22204E6A800DBE7D2 /* Blob.hh */; };
+		27984E342249A247000FE777 /* Database.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27B61DD821DEEC540027CCDB /* Database.hh */; };
+		27984E352249A247000FE777 /* Document.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE4E21DEF54D00B60E3C /* Document.hh */; };
+		27984E362249A247000FE777 /* Query.hh in Headers */ = {isa = PBXBuildFile; fileRef = 277FEE4F21E6AB1100B60E3C /* Query.hh */; };
+		27984E372249A247000FE777 /* Replicator.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27C9B5F121F7D74A0040BC45 /* Replicator.hh */; };
 		27984E402249A85E000FE777 /* CouchbaseLite_Umbrella.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27984E3F2249A85E000FE777 /* CouchbaseLite_Umbrella.hh */; settings = {ATTRIBUTES = (Public, ); }; };
 		27B61D5621D5ABA60027CCDB /* CBLQuery_CAPI.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27B61D5521D5ABA60027CCDB /* CBLQuery_CAPI.cc */; };
 		27B61D6A21D6B60D0027CCDB /* CBLTest.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27B61D6821D6B60D0027CCDB /* CBLTest.hh */; };
@@ -574,10 +574,10 @@
 			isa = PBXGroup;
 			children = (
 				277FEE5021E6BC2100B60E3C /* CouchbaseLite.hh */,
-				277FEE3D21DEF0C700B60E3C /* Base.hh */,
-				275BC4E22204E6A800DBE7D2 /* Blob.hh */,
 				27B61DD821DEEC540027CCDB /* Database.hh */,
 				277FEE4E21DEF54D00B60E3C /* Document.hh */,
+				277FEE3D21DEF0C700B60E3C /* Base.hh */,
+				275BC4E22204E6A800DBE7D2 /* Blob.hh */,
 				277FEE4F21E6AB1100B60E3C /* Query.hh */,
 				27C9B5F121F7D74A0040BC45 /* Replicator.hh */,
 			);
@@ -1088,7 +1088,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\ncp -R vendor/couchbase-lite-core/vendor/fleece/API/fleece/ \"$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/fleece/\"\n";
+			shellScript = "set -e\n# Copy Fleece Headers:\ncp -R vendor/couchbase-lite-core/vendor/fleece/API/fleece/ \"$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/fleece/\"\n\n# Remove C++ Headers (Go to the folder to workaroud rm cmd issue with path including spaces): \npushd \"$BUILT_PRODUCTS_DIR/$PUBLIC_HEADERS_FOLDER_PATH/fleece/\"\nrm -f *.hh\npopd\n";
 		};
 		27DBD088246C94B2002FD7A7 /* Merge static libs */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Xcode/CouchbaseLite.modulemap
+++ b/Xcode/CouchbaseLite.modulemap
@@ -2,18 +2,14 @@ framework module CouchbaseLite {
     header "CouchbaseLite.h"
     header "CBLBase.h"
     header "CBL_Compat.h"
+    header "CBL_Edition.h"
     header "CBLBlob.h"
     header "CBLDatabase.h"
     header "CBLDocument.h"
     header "CBLLog.h"
     header "CBLQuery.h"
     header "CBLReplicator.h"
-
-    module CBLCpp {
-        requires cplusplus
-        header "CouchbaseLite.hh"
-    }
-
+    
     module Fleece {
         header "fleece/Base.h"
         header "fleece/Fleece.h"

--- a/Xcode/mergeIntoStaticLib.sh
+++ b/Xcode/mergeIntoStaticLib.sh
@@ -8,18 +8,18 @@
 #
 # Thanks to <http://geme.github.io/xcode/2016/10/27/BuildPhaseLoopOverInput.html>
 
-# First concatenate the input file paths:
-FILES=""
+# First, setup an array containing input file paths:
+FILES=()
 COUNTER=0
 while [ $COUNTER -lt $SCRIPT_INPUT_FILE_COUNT ]; do
     tmp="SCRIPT_INPUT_FILE_$COUNTER"
-    FILES="$FILES ${!tmp}"
+    FILES+=("${!tmp}")
     let COUNTER=COUNTER+1
 done
-echo "File list is: $FILES"
+echo "File list is: ${FILES[@]}"
 
 # Now use `libtool` to add those files:
-cd $BUILT_PRODUCTS_DIR
-mv $EXECUTABLE_PATH tmp.a
-libtool -static -o $EXECUTABLE_PATH - tmp.a $FILES
+cd "$BUILT_PRODUCTS_DIR"
+mv "$EXECUTABLE_PATH" tmp.a
+libtool -static -o "$EXECUTABLE_PATH" - tmp.a "${FILES[@]}"
 rm tmp.a

--- a/scripts/build_apple.sh
+++ b/scripts/build_apple.sh
@@ -1,0 +1,85 @@
+#!/bin/bash -e
+
+function usage
+{
+  echo "Usage: ${0} [--ee]"
+}
+
+while [[ $# -gt 0 ]]
+do
+  key=${1}
+  case $key in
+    --ee)
+    EE="Y"
+    ;;
+    *)
+    usage
+    exit 3
+    ;;
+  esac
+  shift
+done
+
+if [ -z "$EE" ]
+then
+  echo "Build for Community Edition ..."
+  CONFIGURATION="Release"
+else
+  echo "Build for Enterprise Edition ..."
+  CONFIGURATION="Release_EE"
+fi
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+pushd $SCRIPT_DIR/.. > /dev/null
+
+# Use absolute path to workaround an xcodebuild bug that cannot recognize the dSym files 
+# using their relative paths when creating the xcframework file.
+OUTPUT_DIR=`pwd`/build_apple_out
+BUILD_DIR="$OUTPUT_DIR/build"
+mkdir -p "$BUILD_DIR"
+
+FRAMEWORK_NAME="CouchbaseLite"
+
+# this will be used to collect all destination framework path with `-framework`
+# to include them in `-create-xcframework`
+FRAMEWORK_PATH_ARGS=()
+
+# arg1 = target destination for which the archive is built for. E.g., "generic/platform=iOS"
+function xcarchive
+{
+  PLATFORM_NAME=${1}
+  DESTINATION=${2}
+  
+  echo "Archiving for ${DESTINATION}..."
+  ARCHIVE_PATH=${BUILD_DIR}/${PLATFORM_NAME}
+  xcodebuild archive \
+    -scheme "CBL_C Framework" \
+    -configuration "${CONFIGURATION}" \
+    -destination "${DESTINATION}" \
+    ${BUILD_VERSION} ${BUILD_NUMBER} \
+    -archivePath "${ARCHIVE_PATH}/${FRAMEWORK_NAME}.xcarchive" \
+    "ONLY_ACTIVE_ARCH=NO" "BITCODE_GENERATION_MODE=bitcode" \
+    "CODE_SIGNING_REQUIRED=NO" "CODE_SIGN_IDENTITY=" \
+    "SKIP_INSTALL=NO"
+  
+  FRAMEWORK_PATH_ARGS+=("-framework "${ARCHIVE_PATH}/${FRAMEWORK_NAME}.xcarchive/Products/Library/Frameworks/${FRAMEWORK_NAME}.framework" \
+    -debug-symbols "${ARCHIVE_PATH}/${FRAMEWORK_NAME}.xcarchive/dSYMs/${FRAMEWORK_NAME}.framework.dSYM"")
+  echo "Finished archiving ${DESTINATION}."
+}
+
+# Build and archive binary for each platform:
+xcarchive "iossim" "generic/platform=iOS Simulator"
+xcarchive "ios" "generic/platform=iOS"
+xcarchive "macos" "generic/platform=macOS"
+
+# Create xcframework
+echo "Creating XCFramework...: ${FRAMEWORK_PATH_ARGS}"
+xcodebuild -create-xcframework \
+    -output "${OUTPUT_DIR}/${FRAMEWORK_NAME}.xcframework" \
+    ${FRAMEWORK_PATH_ARGS[*]}
+
+# Remove build directory
+rm -rf ${BUILD_DIR}
+echo "Finished creating XCFramework. Output at "${OUTPUT_DIR}/${FRAMEWORK_NAME}.xcframework""
+popd  > /dev/null


### PR DESCRIPTION
* Added scripts/build_apple.sh for building xcframework. Use —ee option to build ee version.
* Fixed mergeIntoStaticLib.sh for the file paths including space.
* Made C++ headers project level depency so they will not be copied into the framework file.
* Fixed CouchbaseLite.modulemap and Removed C++ headers.
* Removed Fleece’s C++ headers files in Copy Fleece Header build pharse.