### PR TITLE
Fix wrong signature in CBLReplicationFilter

### DIFF
--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -59,7 +59,7 @@ namespace cbl {
     };
 
 
-    using ReplicationFilter = std::function<bool(Document, bool isDeleted)>;
+    using ReplicationFilter = std::function<bool(Document, CBLDocumentFlags flags)>;
 
 
     struct ReplicatorConfiguration {
@@ -120,14 +120,14 @@ namespace cbl {
             CBLReplicatorConfiguration c_config = config;
             _pushFilter = config.pushFilter;
             if (_pushFilter) {
-                c_config.pushFilter = [](void *context, CBLDocument* doc, bool isDeleted) -> bool {
-                    return ((Replicator*)context)->_pushFilter(Document(doc), isDeleted);
+                c_config.pushFilter = [](void *context, CBLDocument* doc, CBLDocumentFlags flags) -> bool {
+                    return ((Replicator*)context)->_pushFilter(Document(doc), flags);
                 };
             }
             _pullFilter = config.pullFilter;
             if (_pullFilter) {
-                c_config.pullFilter = [](void *context, CBLDocument* doc, bool isDeleted) -> bool {
-                    return ((Replicator*)context)->_pullFilter(Document(doc), isDeleted);
+                c_config.pullFilter = [](void *context, CBLDocument* doc, CBLDocumentFlags flags) -> bool {
+                    return ((Replicator*)context)->_pullFilter(Document(doc), flags);
                 };
             }
             c_config.context = this;

--- a/include/cbl/CBLReplicator.h
+++ b/include/cbl/CBLReplicator.h
@@ -79,17 +79,25 @@ typedef CBL_ENUM(uint8_t, CBLReplicatorType) {
     kCBLReplicatorTypePull                ///< Pulling changes from the target
 };
 
+
+/** Flags describing a replicated document. */
+typedef CBL_OPTIONS(unsigned, CBLDocumentFlags) {
+    kCBLDocumentFlagsDeleted        = 1 << 0,   ///< The document has been deleted.
+    kCBLDocumentFlagsAccessRemoved  = 1 << 1    ///< Lost access to the document on the server.
+};
+
+
 /** A callback that can decide whether a particular document should be pushed or pulled.
     @warning  This callback will be called on a background thread managed by the replicator.
                 It must pay attention to thread-safety. It should not take a long time to return,
                 or it will slow down the replicator.
     @param context  The `context` field of the \ref CBLReplicatorConfiguration.
     @param document  The document in question.
-    @param isDeleted True if the document has been deleted.
+    @param flags  Indicates whether the document was deleted or removed.
     @return  True if the document should be replicated, false to skip it. */
 typedef bool (*CBLReplicationFilter)(void* _cbl_nullable context,
                                      CBLDocument* document,
-                                     bool isDeleted);
+                                     CBLDocumentFlags flags);
 
 /** Conflict-resolution callback for use in replications. This callback will be invoked
     when the replicator finds a newer server-side revision of a document that also has local
@@ -292,13 +300,6 @@ _cbl_warn_unused
 CBLListenerToken* CBLReplicator_AddChangeListener(CBLReplicator*,
                                                   CBLReplicatorChangeListener,
                                                   void* _cbl_nullable context) CBLAPI;
-
-
-/** Flags describing a replicated document. */
-typedef CBL_OPTIONS(unsigned, CBLDocumentFlags) {
-    kCBLDocumentFlagsDeleted        = 1 << 0,   ///< The document has been deleted.
-    kCBLDocumentFlagsAccessRemoved  = 1 << 1    ///< Lost access to the document on the server.
-};
 
 
 /** Information about a document that's been pushed or pulled. */

--- a/src/CBLReplicator_Internal.hh
+++ b/src/CBLReplicator_Internal.hh
@@ -287,7 +287,14 @@ private:
     bool _filter(slice docID, slice revID, C4RevisionFlags flags, Dict body, bool pushing) {
         Retained<CBLDocument> doc = new CBLDocument(_conf.database, docID, revID, flags, body);
         CBLReplicationFilter filter = pushing ? _conf.pushFilter : _conf.pullFilter;
-        return filter(_conf.context, doc, (flags & kRevDeleted) != 0);
+        
+        CBLDocumentFlags docFlags = 0;
+        if (flags & kRevDeleted)
+            docFlags |= kCBLDocumentFlagsDeleted;
+        if (flags & kRevPurged)
+            docFlags |= kCBLDocumentFlagsAccessRemoved;
+        
+        return filter(_conf.context, doc, docFlags);
     }
 
 

--- a/test/ReplicatorTest.cc
+++ b/test/ReplicatorTest.cc
@@ -54,11 +54,11 @@ TEST_CASE_METHOD(ReplicatorTest, "Fake Replicate", "[Replicator]") {
     config.endpoint = CBLEndpoint_NewWithURL("ws://fsdfds.vzcsg/foobar"_sl);
     config.authenticator = CBLAuth_NewSession("SyncGatewaySession"_sl, "NOM_NOM_NOM"_sl);
 
-    config.pullFilter = [](void *context, CBLDocument* document, bool isDeleted) -> bool {
+    config.pullFilter = [](void *context, CBLDocument* document, CBLDocumentFlags flags) -> bool {
         return true;
     };
 
-    config.pushFilter = [](void *context, CBLDocument* document, bool isDeleted) -> bool {
+    config.pushFilter = [](void *context, CBLDocument* document, CBLDocumentFlags flags) -> bool {
         return true;
     };
 


### PR DESCRIPTION
* Fixed CBLReplicationFilter signature to use CBLDocumentFlags instead of deleted boolean param.
* Added Push and Pull filter tests.