### PR TITLE
Fix race condition in Query Listener Test

### DIFF
--- a/include/cbl++/Query.hh
+++ b/include/cbl++/Query.hh
@@ -59,7 +59,7 @@ namespace cbl {
         [[nodiscard]] inline ChangeListener addChangeListener(ListenerToken<Query>::Callback);
 
     private:
-        static void _callListener(void *context, CBLQuery*);
+        static void _callListener(void *context, CBLQuery*, CBLListenerToken* token);
         CBL_REFCOUNTED_BOILERPLATE(Query, RefCounted, CBLQuery)
     };
 
@@ -181,7 +181,7 @@ namespace cbl {
     }
 
 
-    inline void Query::_callListener(void *context, CBLQuery *q) {
+    inline void Query::_callListener(void *context, CBLQuery *q, CBLListenerToken* token) {
         ChangeListener::call(context, Query(q));
     }
 

--- a/include/cbl/CBLQuery.h
+++ b/include/cbl/CBLQuery.h
@@ -199,9 +199,11 @@ CBL_REFCOUNTED(CBLResultSet*, ResultSet);
                     prepared for that, you may want to use \ref CBLDatabase_BufferNotifications
                     so that listeners will be called in a safe context.
     @param context  The same `context` value that you passed when adding the listener.
-    @param query  The query that triggered the listener. */
+    @param query  The query that triggered the listener.
+    @param token  The token for obtaining the query results by calling \ref CBLQuery_CopyCurrentResults. */
 typedef void (*CBLQueryChangeListener)(void* _cbl_nullable context,
-                                       CBLQuery* query);
+                                       CBLQuery* query,
+                                       CBLListenerToken* token);
 
 /** Registers a change listener callback with a query, turning it into a "live query" until
     the listener is removed (via \ref CBLListener_Remove).

--- a/src/CBLQuery_Internal.hh
+++ b/src/CBLQuery_Internal.hh
@@ -218,7 +218,7 @@ namespace cbl_internal {
         void call() {
             CBLQueryChangeListener cb = callback();
             if (cb)
-                cb(_context, _query);
+                cb(_context, _query, this);
         }
 
         Retained<CBLResultSet> resultSet() {

--- a/test/QueryTest.cc
+++ b/test/QueryTest.cc
@@ -21,7 +21,6 @@
 #include "fleece/Fleece.hh"
 #include "fleece/Mutable.hh"
 #include <iostream>
-#include <mutex>
 #include <thread>
 
 using namespace std;
@@ -35,29 +34,15 @@ public:
     }
 
     ~QueryTest() {
-        lock_guard<mutex> lock(_mutex);
         CBLResultSet_Release(results);
-        CBLListener_Remove(_token);
+        CBLListener_Remove(listenerToken);
         CBLQuery_Release(query);
-    }
-    
-    void setToken(CBLListenerToken* t) {
-        lock_guard<mutex> lock(_mutex);
-        _token = t;
-    }
-    
-    CBLListenerToken* token() {
-        lock_guard<mutex> lock(_mutex);
-        return _token;
     }
 
     CBLQuery *query =nullptr;
     CBLResultSet *results =nullptr;
+    CBLListenerToken *listenerToken =nullptr;
     int resultCount =-1;
-    
-private:
-    mutable mutex _mutex;
-    CBLListenerToken* _token = nullptr;
 };
 
 
@@ -185,14 +170,14 @@ TEST_CASE_METHOD(QueryTest, "Query Listener", "[Query]") {
     CBLResultSet_Release(results);
 
     cerr << "Adding listener\n";
-    setToken(CBLQuery_AddChangeListener(query, [](void *context, CBLQuery* query) {
+    listenerToken = CBLQuery_AddChangeListener(query, [](void *context, CBLQuery* query, CBLListenerToken* token) {
         auto self = (QueryTest*)context;
         CBLError error;
-        auto newResults = CBLQuery_CopyCurrentResults(query, self->token(), &error);
+        auto newResults = CBLQuery_CopyCurrentResults(query, token, &error);
         CHECK(newResults);
         self->resultCount = countResults(newResults);
         CBLResultSet_Release(newResults);
-    }, this));
+    }, this);
 
     cerr << "Waiting for listener...\n";
     resultCount = -1;


### PR DESCRIPTION
Synchronize when get and set the listener token in QueryTest class.