### PR TITLE
Feature/cbl c/cbl 1783

### DIFF
--- a/include/cbl++/Query.hh
+++ b/include/cbl++/Query.hh
@@ -56,7 +56,7 @@ namespace cbl {
 
         class ChangeListener;
 
-        [[nodiscard]] inline ChangeListener addChangeListener(ListenerToken<Query>::Callback);
+        [[nodiscard]] inline ChangeListener addChangeListener(ListenerToken<ResultSet>::Callback);
 
     private:
         static void _callListener(void *context, CBLQuery*, CBLListenerToken* token);
@@ -155,10 +155,10 @@ namespace cbl {
     }
 
 
-    class Query::ChangeListener : public ListenerToken<Query> {
+    class Query::ChangeListener : public ListenerToken<ResultSet> {
     public:
         ChangeListener(Query query, Callback cb)
-        :ListenerToken<Query>(cb)
+        :ListenerToken<ResultSet>(cb)
         ,_query(std::move(query))
         { }
 
@@ -182,7 +182,10 @@ namespace cbl {
 
 
     inline void Query::_callListener(void *context, CBLQuery *q, CBLListenerToken* token) {
-        ChangeListener::call(context, Query(q));
+        CBLError error;
+        auto rs = CBLQuery_CopyCurrentResults(q, token, &error);
+        check(rs, error);
+        ChangeListener::call(context, ResultSet::adopt(rs));
     }
 
 

--- a/test/QueryTest.cc
+++ b/test/QueryTest.cc
@@ -266,7 +266,8 @@ TEST_CASE_METHOD(QueryTest_Cpp, "Query Listener, C++ API", "[Query]") {
 
     cerr << "Adding listener\n";
     atomic_int resultCount{-1};
-    Query::ChangeListener listenerToken = query.addChangeListener([&](ResultSet rs) {
+    Query::ChangeListener listenerToken = query.addChangeListener([&](Query::Change change) {
+        ResultSet rs = change.results();
         resultCount = countResults(rs);
     });
 

--- a/test/QueryTest.cc
+++ b/test/QueryTest.cc
@@ -22,6 +22,7 @@
 #include "fleece/Mutable.hh"
 #include <iostream>
 #include <thread>
+#include <atomic>
 
 using namespace std;
 using namespace fleece;
@@ -265,7 +266,7 @@ TEST_CASE_METHOD(QueryTest_Cpp, "Query Listener, C++ API", "[Query]") {
     }
 
     cerr << "Adding listener\n";
-    atomic_int resultCount{-1};
+    std::atomic_int resultCount{-1};
     Query::ChangeListener listenerToken = query.addChangeListener([&](Query::Change change) {
         ResultSet rs = change.results();
         resultCount = countResults(rs);

--- a/test/QueryTest.cc
+++ b/test/QueryTest.cc
@@ -247,9 +247,6 @@ TEST_CASE_METHOD(QueryTest_Cpp, "Query C++ API", "[Query]") {
 }
 
 
-
-// CBL-1783 : Disable the test until the issue is fixed
-
 static int countResults(ResultSet &results) {
     int n = 0;
     for (CBL_UNUSED auto &result : results)


### PR DESCRIPTION
This is the motivation of the change. Currently, we add listener as follows,
ChangeListener listener = addChangeListener(callback), where the callback gets called when the change takes place, and then we can get the change from "listener," as listener.result(). One place to handle the change is inside the callback. However, before "addChangeListener" is returned, listener is incomplete. This actually caused crashing due to the race condition, whereby the callback is something like "callback = [](){ listener.results();}"
Whereas this use itself is bug, which can be fixed by, inside the callback, waiting for the add function to return. However, we want to improve the API to be less liable to that kind of error. After discussing with Pasin, we derived this solution of this PR. We provide the object, Change, as an argument of the callback. With this object, the author of the callback may safely get the results. Of course, the original function listener is not removed. Users may still call listener.results() in the same thread as the one that runs addChangeListener(). We just removed little awkwardness to get the change results from inside the callback.