### PR TITLE
Add auto-purge config to Replicator Configuration

### DIFF
--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -72,6 +72,8 @@ namespace cbl {
         CBLReplicatorType replicatorType    = kCBLReplicatorTypePushAndPull;
         bool continuous                     = false;
         
+        bool enableAutoPurge                = true;
+        
         unsigned maxAttempts                = 0;
         unsigned maxAttemptWaitTime         = 0;
         
@@ -97,6 +99,7 @@ namespace cbl {
             conf.replicatorType = replicatorType;
             conf.continuous = continuous;
             conf.maxAttempts = maxAttempts;
+            conf.disableAutoPurge = !enableAutoPurge;
             conf.maxAttemptWaitTime = maxAttemptWaitTime;
             conf.heartbeat = heartbeat;
             conf.authenticator = authenticator.ref();

--- a/include/cbl/CBLReplicator.h
+++ b/include/cbl/CBLReplicator.h
@@ -149,6 +149,8 @@ typedef struct {
     CBLEndpoint* endpoint;              ///< The address of the other database to replicate with
     CBLReplicatorType replicatorType;   ///< Push, pull or both
     bool continuous;                    ///< Continuous replication?
+    //-- Auto-Purge:
+    bool disableAutoPurge;              ///< Disable/Enable auto-purging documents when the user's access to the documents has been revoked.
     //-- Retry Logic:
     unsigned maxAttempts;               ///< Max retry attempts where the initial connect to replicate counts toward the given value.
                                         ///< Specify 0 to use the default value, 10 times for a non-continuous replicator and max-int time for a continuous replicator. Specify 1 means there will be no retry after the first attempt.

--- a/src/CBLReplicatorConfig.hh
+++ b/src/CBLReplicatorConfig.hh
@@ -227,6 +227,11 @@ namespace cbl_internal {
                 enc.endDict();
             }
             
+            if (disableAutoPurge) {
+                enc.writeKey(slice(kC4ReplicatorOptionAutoPurge));
+                enc.writeBool(!disableAutoPurge);
+            }
+            
             if (maxAttempts > 0) {
                 enc.writeKey(slice(kC4ReplicatorOptionMaxRetries));
                 enc.writeUInt(maxAttempts - 1);


### PR DESCRIPTION
* Added disableAutoPurge to CBLReplicatorConfiguration. Per API Spec, only CBL-C will use disableAutoPurge to allow the default value to false while the other platforms will use enableAutoPurge (default = true).
* Updated LiteCore to the latest dev branch to pickup auto-purge change.
* Note: This feature requires functional tests.