### PR TITLE
CBL-1970 : Implement disableAutoPurge config

### DIFF
--- a/include/cbl++/Replicator.hh
+++ b/include/cbl++/Replicator.hh
@@ -72,6 +72,8 @@ namespace cbl {
         CBLReplicatorType replicatorType    = kCBLReplicatorTypePushAndPull;
         bool continuous                     = false;
         
+        bool enableAutoPurge                = true;
+        
         unsigned maxAttempts                = 0;
         unsigned maxAttemptWaitTime         = 0;
         
@@ -96,6 +98,7 @@ namespace cbl {
             conf.endpoint = endpoint.ref();
             conf.replicatorType = replicatorType;
             conf.continuous = continuous;
+            conf.disableAutoPurge = !enableAutoPurge;
             conf.maxAttempts = maxAttempts;
             conf.maxAttemptWaitTime = maxAttemptWaitTime;
             conf.heartbeat = heartbeat;

--- a/include/cbl/CBLReplicator.h
+++ b/include/cbl/CBLReplicator.h
@@ -149,6 +149,8 @@ typedef struct {
     CBLEndpoint* endpoint;              ///< The address of the other database to replicate with
     CBLReplicatorType replicatorType;   ///< Push, pull or both
     bool continuous;                    ///< Continuous replication?
+    //-- Auto Purge:
+    bool disableAutoPurge;              ///< Disable/Enable auto-purging documents when the user's access to the documents has been revoked.
     //-- Retry Logic:
     unsigned maxAttempts;               ///< Max retry attempts where the initial connect to replicate counts toward the given value.
                                         ///< Specify 0 to use the default value, 10 times for a non-continuous replicator and max-int time for a continuous replicator. Specify 1 means there will be no retry after the first attempt.

--- a/src/CBLReplicatorConfig.hh
+++ b/src/CBLReplicatorConfig.hh
@@ -227,6 +227,11 @@ namespace cbl_internal {
                 enc.endDict();
             }
             
+            if (disableAutoPurge) {
+                enc.writeKey(slice(kC4ReplicatorOptionAutoPurge));
+                enc.writeBool(!disableAutoPurge);
+            }
+            
             if (maxAttempts > 0) {
                 enc.writeKey(slice(kC4ReplicatorOptionMaxRetries));
                 enc.writeUInt(maxAttempts - 1);


### PR DESCRIPTION
Added disableAutoPurge property to the CBLReplicatorConfiguration. Per discussion in the API spec, CBL-C will have a negative property to allow the default value as false, while the other platforms including c++ binding will have enableAutoPurge property.