### PR TITLE
Add initializer to call enablingFatalExceptionBacktrace()

### DIFF
--- a/src/Internal.cc
+++ b/src/Internal.cc
@@ -24,6 +24,14 @@ using namespace fleece;
 
 namespace cbl_internal {
 
+    // Initializer that is called once when the library (sCBLInitializer) is loaded:
+    struct CBLInitializer {
+    public:
+        CBLInitializer () {
+            c4log_enableFatalExceptionBacktrace();
+        }
+    } sCBLInitializer;
+
     void BridgeException(const char *fnName, CBLError *outError) noexcept {
         C4Error error = C4Error::fromCurrentException();
         if (outError)


### PR DESCRIPTION
Use a static variable for global initializing that calls enablingFatalExceptionBacktrace().